### PR TITLE
Fix manifest icons path

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -8,12 +8,12 @@
     "theme_color": "#4CAF50",
     "icons": [
       {
-        "src": "/images/icone",
+        "src": "icone.png",
         "sizes": "192x192",
         "type": "image/png"
       },
       {
-        "src": "/images/icone",
+        "src": "icone.png",
         "sizes": "512x512",
         "type": "image/png"
       }


### PR DESCRIPTION
## Summary
- correct manifest icon paths from `/images/icone` to `icone.png`

## Testing
- `python3 -m json.tool manifest.json`

------
https://chatgpt.com/codex/tasks/task_e_68829354c97c832aa86ef901630dfbfc