### PR TITLE
Fix typo, add README and JSON tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# KidsXpérience
+
+KidsXpérience est une application web ludique destinée aux enfants de 8 à 13 ans pour équilibrer leurs activités quotidiennes. Elle propose des activités, bonnes actions et punitions adaptées pour encourager les comportements positifs.
+
+## Utilisation
+
+1. Ouvrez `index.html` dans votre navigateur pour lancer l'application.
+2. Depuis le navigateur, vous pouvez ajouter l'application à l'écran d'accueil pour l'utiliser comme PWA.
+3. Les fichiers JSON (`activites.json`, `bonnes_actions.json`, `punitions.json`) fournissent les données chargées par l'application.
+
+## Tests
+
+Des tests basiques permettent de vérifier l'intégrité des fichiers JSON. Exécutez :
+
+```bash
+npm test
+```
+
+Assurez-vous d'avoir Node.js installé.

--- a/index.html
+++ b/index.html
@@ -171,7 +171,7 @@
     </style>
 </head>
 <body>
-    <h1>KidXpérience</h1>
+    <h1>KidsXpérience</h1>
     
     <!-- Bouton pour choisir une activité -->
     <button id="activityButton" onclick="choisirActivite()">

--- a/manifest.json
+++ b/manifest.json
@@ -8,12 +8,12 @@
     "theme_color": "#4CAF50",
     "icons": [
       {
-        "src": "/images/icone",
+        "src": "/icone.png",
         "sizes": "192x192",
         "type": "image/png"
       },
       {
-        "src": "/images/icone",
+        "src": "/icone.png",
         "sizes": "512x512",
         "type": "image/png"
       }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "kidsxperience",
+  "version": "1.0.0",
+  "description": "Validation tests for KidsXpérience data",
+  "scripts": {
+    "test": "node test/validate-json.js"
+  }
+}

--- a/test/validate-json.js
+++ b/test/validate-json.js
@@ -1,0 +1,34 @@
+const fs = require('fs');
+
+const files = [
+  { path: 'activites.json', required: ['nom', 'description', 'adresse', 'budget'] },
+  { path: 'bonnes_actions.json', required: ['nom', 'description'] },
+  { path: 'punitions.json', required: ['nom', 'description'] }
+];
+
+let hasError = false;
+
+files.forEach(file => {
+  const data = JSON.parse(fs.readFileSync(file.path, 'utf8'));
+  if (!Array.isArray(data)) {
+    console.error(`${file.path} should contain an array`);
+    hasError = true;
+    return;
+  }
+
+  data.forEach((entry, index) => {
+    file.required.forEach(field => {
+      if (!(field in entry)) {
+        console.error(`${file.path} -> entry ${index} missing field '${field}'`);
+        hasError = true;
+      }
+    });
+  });
+});
+
+if (hasError) {
+  console.error('Validation failed');
+  process.exit(1);
+} else {
+  console.log('All JSON files are valid');
+}


### PR DESCRIPTION
## Summary
- align the heading with the manifest app name
- correct icon paths in `manifest.json`
- add basic usage instructions in `README.md`
- provide a node-based test for validating JSON data

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68829354c874832ab0f577291638816d